### PR TITLE
add: per value exception case

### DIFF
--- a/prediction.py
+++ b/prediction.py
@@ -29,7 +29,7 @@ def predict(company_code):
             company_per = float(line[3])
             same_category_per = float(line[4])
 
-    if company_per >= 0 and same_category_per >= 0:
+    if company_per >= 0 and same_category_per > 0:
         per_value = 1 - company_per / same_category_per  # 1 - 자기 회사 PER / 동일 업종 PER
     else:
         per_value = 0


### PR DESCRIPTION
**AS-IS**
- 1 - 자기회사 PER / 동일업종 PER

문제점
- 자기회사 PER 만 양수이거나, 동일업종 PER 만 양수 이거나, 둘다 음수인 경우에는 PER 을 비교하는게 의미가 없는데 최종 주가를 예측할 때 값이 들어가게 된다.

**TO-BE**
- 자기회사 PER  >= 0, 동일업종 PER > 0 인 경우에만 값을 계산하고 그렇지 않은 경우에는 0 을 넣게끔 수정했다.